### PR TITLE
Unify admin recommendations: persistent prospect + robust prospect extraction

### DIFF
--- a/src/app/admin/follow-ups/page.tsx
+++ b/src/app/admin/follow-ups/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/components/ui/card";
+import { FollowUpsList, RecommendationsDialog } from "@/components/admin";
+import { useChatSummaries } from "@/hooks/useChatSummaries";
+import { getRecommendationsWithCache } from "@/hooks/useAdminRecommendations";
+import type { ChatRecommendationsData } from "@/types/analytics";
+import { extractProspectFromSummary } from "@/lib/prospect";
+
+export default function AdminFollowUpsPage() {
+  const [recOpen, setRecOpen] = useState(false);
+  const [recLoading, setRecLoading] = useState(false);
+  const [recData, setRecData] = useState<ChatRecommendationsData | null>(null);
+  const [currentRecItem, setCurrentRecItem] = useState<{
+    sessionId: string;
+    summary: string;
+    sentiment: string | null;
+  } | null>(null);
+  const [currentProspect, setCurrentProspect] = useState<ReturnType<typeof extractProspectFromSummary> | null>(null);
+
+  const { summaries, deleteSummary } = useChatSummaries("30d");
+
+  async function handleRecommend(item: {
+    sessionId: string;
+    summary: string;
+    sentiment: string | null;
+  }) {
+    try {
+      setRecLoading(true);
+      setRecOpen(true);
+      setRecData(null);
+      setCurrentRecItem(item);
+      const prospect = extractProspectFromSummary(item.summary);
+      setCurrentProspect(prospect);
+      const data = await getRecommendationsWithCache({
+        sessionId: item.sessionId,
+        summary: item.summary,
+        sentiment: item.sentiment,
+        prospect,
+      });
+      setRecData(data);
+    } catch {
+      setRecData({ nextBestAction: "", recommendedActions: [], journey: [] });
+    } finally {
+      setRecLoading(false);
+    }
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <Card variant="glass" className="p-7">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-2xl md:text-3xl font-semibold tracking-tight">
+            Follow-ups
+          </h1>
+          <p className="text-muted-foreground">
+            Review AI suggestions, mark follow-ups complete, and set reminders.
+          </p>
+        </div>
+      </Card>
+
+      <FollowUpsList
+        items={summaries}
+        onRecommend={(item) =>
+          handleRecommend({
+            sessionId: item.sessionId,
+            summary: item.summary,
+            sentiment: item.sentiment,
+          })
+        }
+        onDelete={deleteSummary}
+      />
+
+      <RecommendationsDialog
+        open={recOpen}
+        onOpenChange={setRecOpen}
+        loading={recLoading}
+        data={recData}
+        initialProspect={currentProspect || undefined}
+        onRegenerate={async (prospect) => {
+          if (!currentRecItem) return;
+          try {
+            setRecLoading(true);
+            const fresh = await getRecommendationsWithCache(
+              {
+                sessionId: currentRecItem.sessionId,
+                summary: currentRecItem.summary,
+                sentiment: currentRecItem.sentiment,
+                prospect,
+              },
+              { force: true }
+            );
+            setRecData(fresh);
+            setCurrentProspect(prospect);
+          } finally {
+            setRecLoading(false);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/lib/prospect.ts
+++ b/src/lib/prospect.ts
@@ -1,0 +1,39 @@
+export type Prospect = {
+  name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  company?: string | null;
+  interest?: string | null;
+  budget?: string | null;
+};
+
+// Extracts prospect details from a chat summary string.
+// Example summary format:
+// "Alex Positive from Sunrise Corp submitted a partnership inquiry via the website. They are interested in: Gold sponsorship. Budget indicated: $25k. Contact: alex.pos@example.com · +1-111-111-1111. Source: website. Message: We are excited about partnering and ready to move fast."
+export function extractProspectFromSummary(summary: string): Prospect {
+  const nameMatch = summary.match(/^(.+?)\s+from\s+/);
+  const companyMatch = summary.match(/from\s+(.+?)\s+submitted/);
+  const interestMatch = summary.match(/interested in:\s*([^.]+)\./);
+  const budgetMatch = summary.match(/Budget indicated:\s*([^.]+)\./);
+  // Capture the rest of the line after "Contact:" (emails/phones may be separated by dot, bullet, etc.)
+  const contactSection = summary.match(/Contact:\s*([^\n]+)/i);
+
+  const name = nameMatch?.[1]?.trim() || null;
+  const company = companyMatch?.[1]?.trim() || null;
+  const interest = interestMatch?.[1]?.trim() || null;
+  const budget = budgetMatch?.[1]?.trim() || null;
+
+  let email: string | null = null;
+  let phone: string | null = null;
+  if (contactSection) {
+    const contactText = contactSection[1]?.trim() || "";
+    // Extract email anywhere in the contact text
+    const emailMatch = contactText.match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i);
+    if (emailMatch) email = emailMatch[0];
+    // Extract a phone-like sequence (supports +, spaces, dashes, parentheses)
+    const phoneMatch = contactText.match(/\+?\d[\d\s\-().]{6,}\d/);
+    if (phoneMatch) phone = phoneMatch[0].trim();
+  }
+
+  return { name, email, phone, company, interest, budget };
+}

--- a/tests/lib/prospect_extractor.test.ts
+++ b/tests/lib/prospect_extractor.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { extractProspectFromSummary, type Prospect } from "@/lib/prospect";
+
+// Helper to drop nulls for easier assertions
+function clean(p: Prospect) {
+  const o: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(p)) {
+    if (v !== null && v !== undefined && v !== "") o[k] = v;
+  }
+  return o as Required<Prospect> | Partial<Prospect>;
+}
+
+describe("extractProspectFromSummary", () => {
+  it("parses full example with email and phone", () => {
+    const summary =
+      "Alex Positive from Sunrise Corp submitted a partnership inquiry via the website. They are interested in: Gold sponsorship. Budget indicated: $25k. Contact: alex.pos@example.com · +1-111-111-1111. Source: website. Message: We are excited about partnering and ready to move fast.";
+
+    const p = extractProspectFromSummary(summary);
+    const got = clean(p);
+
+    expect(got.name).toBe("Alex Positive");
+    expect(got.company).toBe("Sunrise Corp");
+    expect(got.interest).toBe("Gold sponsorship");
+    expect(got.budget).toBe("$25k");
+    expect(got.email).toBe("alex.pos@example.com");
+    expect(got.phone).toBe("+1-111-111-1111");
+  });
+
+  it("parses when only email is present in contact", () => {
+    const summary =
+      "Blake from Nova Inc submitted a partnership inquiry via the website. They are interested in: Booth & speaking. Budget indicated: ~IDR 50jt. Contact: blake@nova.co. Source: website.";
+
+    const p = extractProspectFromSummary(summary);
+    const got = clean(p);
+
+    expect(got.name).toBe("Blake");
+    expect(got.company).toBe("Nova Inc");
+    expect(got.interest).toBe("Booth & speaking");
+    expect(got.budget).toBe("~IDR 50jt");
+    expect(got.email).toBe("blake@nova.co");
+    expect(got.phone).toBeUndefined();
+  });
+
+  it("parses when only phone is present in contact", () => {
+    const summary =
+      "Citra from Garuda Ventures submitted a partnership inquiry via the website. They are interested in: Sponsorship. Budget indicated: TBD. Contact: +62 812-3456-7890. Source: website.";
+
+    const p = extractProspectFromSummary(summary);
+    const got = clean(p);
+
+    expect(got.name).toBe("Citra");
+    expect(got.company).toBe("Garuda Ventures");
+    expect(got.interest).toBe("Sponsorship");
+    expect(got.budget).toBe("TBD");
+    expect(got.email).toBeUndefined();
+    expect(got.phone).toBe("+62 812-3456-7890");
+  });
+});


### PR DESCRIPTION
This PR unifies recommendation flows across admin pages and preserves prospect data during refinement.\n\nChanges:\n- Admin pages pass initialProspect and keep currentProspect across regenerate\n- Robust contact parsing (email/phone) in extractProspectFromSummary\n- Added unit tests for extractor (all tests passing)\n\nManual verification: dialog shows personalized name/company, Regenerate keeps fields, and email/WhatsApp links are prefilled with templates and contact info.