### PR TITLE
test(e2e): avoid hardcoded port in cookie; assert non-empty body on 2…

### DIFF
--- a/e2e/anchors.spec.ts
+++ b/e2e/anchors.spec.ts
@@ -18,7 +18,11 @@ test.describe("homepage anchors", () => {
       {
         name: "auth-token",
         value: token,
-        url: "http://localhost:3000",
+        domain: "localhost",
+        path: "/",
+        httpOnly: false,
+        secure: false,
+        sameSite: "Lax",
       },
     ]);
     await page.goto("/");

--- a/e2e/downloads.spec.ts
+++ b/e2e/downloads.spec.ts
@@ -11,6 +11,10 @@ test.describe("public downloads", () => {
       const res = await request.get(`/api/documents/public/download/${key}`);
       const status = res.status();
       expect([200, 302]).toContain(status);
+      if (status === 200) {
+        const buf = await res.body();
+        expect(buf.byteLength).toBeGreaterThan(0);
+      }
     });
   }
 });


### PR DESCRIPTION
…00 downloads